### PR TITLE
Potential fix for code scanning alert no. 19: Uncontrolled data used in path expression

### DIFF
--- a/internal/store/system/systemd_time.go
+++ b/internal/store/system/systemd_time.go
@@ -163,6 +163,10 @@ func GetNextSchedule(job *types.Job) (*time.Time, error) {
 }
 
 func SetSchedule(job types.Job) error {
+	if strings.Contains(job.ID, "/") || strings.Contains(job.ID, "\\") || strings.Contains(job.ID, "..") {
+		return fmt.Errorf("SetSchedule: invalid job ID -> %s", job.ID)
+	}
+
 	svcPath := fmt.Sprintf("pbs-plus-job-%s.service", strings.ReplaceAll(job.ID, " ", "-"))
 	fullSvcPath := filepath.Join(constants.TimerBasePath, svcPath)
 


### PR DESCRIPTION
Potential fix for [https://github.com/sonroyaalmerol/pbs-plus/security/code-scanning/19](https://github.com/sonroyaalmerol/pbs-plus/security/code-scanning/19)

To fix the problem, we need to validate the `job.ID` before using it to construct file paths. We should ensure that the `job.ID` does not contain any path separators or sequences that could lead to path traversal attacks. This can be done by checking for the presence of "/" or "\\" characters and ".." sequences in the `job.ID`.

1. Add a validation function to check the `job.ID` for invalid characters or sequences.
2. Use this validation function in the `SetSchedule` function before constructing the file paths.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
