### PR TITLE
Potential fix for code scanning alert no. 13: Uncontrolled data used in path expression

### DIFF
--- a/internal/store/system/systemd_time.go
+++ b/internal/store/system/systemd_time.go
@@ -16,6 +16,10 @@ import (
 )
 
 func generateTimer(job *types.Job) error {
+	if strings.Contains(job.ID, "/") || strings.Contains(job.ID, "\\") || strings.Contains(job.ID, "..") {
+		return fmt.Errorf("generateTimer: invalid job ID -> %s", job.ID)
+	}
+
 	content := fmt.Sprintf(`[Unit]
 Description=%s Backup Job Timer
 


### PR DESCRIPTION
Potential fix for [https://github.com/sonroyaalmerol/pbs-plus/security/code-scanning/13](https://github.com/sonroyaalmerol/pbs-plus/security/code-scanning/13)

To fix the problem, we need to validate the `job.ID` before using it to construct file paths. We should ensure that the `job.ID` does not contain any path separators ("/" or "\\") or sequences like ".." that could lead to path traversal. This can be done by adding a validation check before constructing the file paths.

1. Add a validation function to check the `job.ID` for invalid characters.
2. Use this validation function in the `generateTimer` and `SetSchedule` functions to ensure the `job.ID` is safe before constructing file paths.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
