### PR TITLE
Potential fix for code scanning alert no. 14: Uncontrolled data used in path expression

### DIFF
--- a/internal/store/system/systemd_time.go
+++ b/internal/store/system/systemd_time.go
@@ -16,6 +16,10 @@ import (
 )
 
 func generateTimer(job *types.Job) error {
+	if strings.Contains(job.ID, "/") || strings.Contains(job.ID, "\\") || strings.Contains(job.ID, "..") {
+		return fmt.Errorf("generateTimer: invalid job ID -> %s", job.ID)
+	}
+
 	content := fmt.Sprintf(`[Unit]
 Description=%s Backup Job Timer
 
@@ -43,8 +47,12 @@ WantedBy=timers.target`, job.ID, job.Schedule)
 
 	return nil
 }
-
+
 func generateService(job *types.Job) error {
+	if strings.Contains(job.ID, "/") || strings.Contains(job.ID, "\\") || strings.Contains(job.ID, "..") {
+		return fmt.Errorf("generateService: invalid job ID -> %s", job.ID)
+	}
+
 	content := fmt.Sprintf(`[Unit]
 Description=%s Backup Job Service
 After=network-online.target


### PR DESCRIPTION
Potential fix for [https://github.com/sonroyaalmerol/pbs-plus/security/code-scanning/14](https://github.com/sonroyaalmerol/pbs-plus/security/code-scanning/14)

To fix the problem, we need to ensure that the `job.ID` is properly validated before it is used to construct file paths. This involves checking that the `job.ID` does not contain any path separators or sequences that could lead to path traversal. We should apply this validation in the `generateService` and `generateTimer` functions.

1. Add a validation function to check for invalid characters in `job.ID`.
2. Use this validation function in the `generateService` and `generateTimer` functions before constructing file paths.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
